### PR TITLE
Disable port in redirect headers

### DIFF
--- a/images/runtime/php-fpm/nginx_conf/default.conf
+++ b/images/runtime/php-fpm/nginx_conf/default.conf
@@ -6,6 +6,7 @@ server {
     root /home/site/wwwroot;
     index  index.php index.html index.htm;
     server_name  example.com www.example.com; 
+    port_in_redirect off;
 
     location / {            
         index  index.php index.html index.htm hostingstart.html;


### PR DESCRIPTION
nginx listening port should not be added to Location: header when nginx sends redirect response.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
